### PR TITLE
Add missing API partial for stripe gateway

### DIFF
--- a/lib/spree_affirm/engine.rb
+++ b/lib/spree_affirm/engine.rb
@@ -23,5 +23,9 @@ module SpreeAffirm
     initializer "spree.spree_affirm.payment_methods", :after => "spree.register.payment_methods" do |app|
         app.config.spree.payment_methods << Spree::Gateway::Affirm
     end
+
+    if SolidusSupport.api_available?
+      paths["app/views"] << "lib/views/api"
+    end
   end
 end

--- a/lib/views/api/spree/api/payments/source_views/_affirm.json.jbuilder
+++ b/lib/views/api/spree/api/payments/source_views/_affirm.json.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.partial!('spree/api/payments/source_views/gateway', payment_source: payment_source)


### PR DESCRIPTION
This source view jbuilder is needed for each payment method in order to load the order api endpoint.

See this similar commit in solidus_gateway
https://github.com/solidusio/solidus_gateway/commit/739c846dbc680852a9d8a0e83602d11559d951d8